### PR TITLE
Bump to Quarkus 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ exit 0
 
 ## Azure Resource Group examples
 
-|    | Name | Link | Status
-| -- | ---- | ---- | ------ 
-| 1. | [Create an Azure Resource Group](group/create/) | [Workflow](.github/workflows/group_create_README_md.yml) | ![group/create/README.md](https://github.com/Azure-Samples/java-on-azure-examples/workflows/group/create/README.md/badge.svg)
-| 2. | [Delete an Azure Resource Group](group/delete/) | [Workflow](.github/workflows/group_delete_README_md.yml) | ![group/delete/README.md](https://github.com/Azure-Samples/java-on-azure-examples/workflows/group/delete/README.md/badge.svg)
+| Name | Link | Status
+| ---- | ---- | ------ 
+| 1. [Create an Azure Resource Group](group/create/) | [Workflow](.github/workflows/group_create_README_md.yml) | ![group/create/README.md](https://github.com/Azure-Samples/java-on-azure-examples/workflows/group/create/README.md/badge.svg)
+| 2. [Delete an Azure Resource Group](group/delete/) | [Workflow](.github/workflows/group_delete_README_md.yml) | ![group/delete/README.md](https://github.com/Azure-Samples/java-on-azure-examples/workflows/group/delete/README.md/badge.svg)
 
 ## Azure Service Bus examples
 

--- a/appservice/javase-quarkus/pom.xml
+++ b/appservice/javase-quarkus/pom.xml
@@ -13,15 +13,14 @@
     <properties>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>1.3.2.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.3.2.Final</quarkus.platform.version>
-        <surefire-plugin.version>2.22.1</surefire-plugin.version>
+        <quarkus.platform.version>2.0.2.Final</quarkus.platform.version>
+        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <appName>javase-quarkus-${example.postfix}</appName>
         <appServicePlan>azure-examples-appserviceplan</appServicePlan>
         <resourceGroup>azure-examples</resourceGroup>
@@ -44,6 +43,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -56,13 +59,16 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-plugin.version}</version>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -70,14 +76,18 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
+                <configuration>
+                  <parameters>${maven.compiler.parameters}</parameters>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <configuration>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemProperties>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -90,7 +100,7 @@
                     <appServicePlanName>${appServicePlan}</appServicePlanName>
                     <runtime>
                         <os>linux</os>
-                        <javaVersion>jre8</javaVersion>
+                        <javaVersion>jre11</javaVersion>
                     </runtime>
                     <appSettings>
                         <property>

--- a/appservice/javase-quarkus/src/main/resources/application.properties
+++ b/appservice/javase-quarkus/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-# Configuration file
-# key = value
+quarkus.package.type=uber-jar


### PR DESCRIPTION
Quarkus 2.x support JDK 11+ (not JDK8) and the default packaging is not Uber-Jar anymore (it has to be specified in the `applicationproperties` with `quarkus.package.type=uber-jar`) 

PS: I also fixed the the table in Markdown. It has an extra column. It displays fine on GitHub, but breaks on Intellij Idea