### PR TITLE
Pass the resource group in the command line

### DIFF
--- a/acr/quarkus/README.md
+++ b/acr/quarkus/README.md
@@ -45,7 +45,7 @@ To build and push the Docker image to your ACR use the command lines below:
 ```shell
   export ACR_QUARKUS_IMAGE=quarkus:latest
 
-  az acr build --registry $ACR_NAME --image $ACR_QUARKUS_IMAGE .
+  az acr build --registry $ACR_NAME --resource-group $RESOURCE_GROUP --image $ACR_QUARKUS_IMAGE .
 ```
 
 <!-- workflow.run()


### PR DESCRIPTION
I realised that I had a default resource group configured (`az configure -l`) so the command wasn't creating the resource in the right resource group. By passing the resource group as a parameter, it handles the ambiguity.
