### PR TITLE
Fixes #417 - Support Java 17 for GitHub workflows

### DIFF
--- a/.github/workflows/_generate_workflows.yml
+++ b/.github/workflows/_generate_workflows.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         rm -rf .github/workflows/*_md.yml
         rm -rf .script
-        curl -L https://repo1.maven.org/maven2/com/manorrock/parrot/parrot/23.10.0/parrot-23.10.0.jar -o parrot.jar
+        curl -L https://repo1.maven.org/maven2/com/manorrock/parrot/parrot/24.2.0/parrot-24.2.0.jar -o parrot.jar
         java -jar parrot.jar --baseDirectory . --outputDirectory .github/workflows
         git config --global user.email "noreply@microsoft.com"
         git config --global user.name "Automated workflow"


### PR DESCRIPTION
Updated Manorrock Parrot to a version that supports selecting the Java version for a workflow